### PR TITLE
< and > is properly escaped: &lt; and &gt;

### DIFF
--- a/content/en/docs/ct-logs.html
+++ b/content/en/docs/ct-logs.html
@@ -48,7 +48,7 @@ aliases:
 <p>To enumerate the included roots for a particular CT log, you can run the following command in the terminal of your choice:</p>
 <pre>
 $ for i in $(curl -s https://oak.ct.letsencrypt.org/2020/ct/v1/get-roots | jq -r '.certificates[]'); do
-    echo '------'; base64 -d <<< "${i}" | openssl x509 -inform der -noout -issuer -serial
+    echo '------'; base64 -d &lt;&lt;&lt; "${i}" | openssl x509 -inform der -noout -issuer -serial
 done
 </pre>
 
@@ -58,8 +58,8 @@ $ echo | \
 openssl s_client \
     -connect "letsencrypt.org":443 \
     -servername "letsencrypt.org" \
-    -verify_hostname "letsencrypt.org" 2>/dev/null | \
-sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > example.crt
+    -verify_hostname "letsencrypt.org" 2&gt;/dev/null | \
+sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' &gt; example.crt
 </pre>
 
 <p>To <i>easily</i> submit the certificate above to a CT log, you can use the JSON generator provided by <a href="https://crt.sh/gen-add-chain">https://crt.sh/gen-add-chain</a>. The crt.sh utility will return a JSON bundle. With the JSON bundle downloaded to your computer, issue the following command to perform the add-chain operation (<a href="https://tools.ietf.org/html/rfc6962#section-4.1">RFC 6962 section 4.1</a>) to submit the certificate to a CT log. The output will contain a signature which is in fact an <a href="https://letsencrypt.org/2018/04/04/sct-encoding.html">SCT</a>. More on the signature in a moment.</p>
@@ -75,13 +75,13 @@ $ curl \
 
 <p>To confirm that the CT log was signed by the Oak 2020 shard, we use the id field from the command above and run it through the following command. The result of this will output the Log ID of the CT log.</p>
 <pre>
-$ base64 -d <<< "5xLysDd+GmL7jskMYYTx6ns3y1YdESZb8+DzS/JBVG4=" | xxd -p -c 64 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
+$ base64 -d &lt;&lt;&lt; "5xLysDd+GmL7jskMYYTx6ns3y1YdESZb8+DzS/JBVG4=" | xxd -p -c 64 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
 E7:12:F2:B0:37:7E:1A:62:FB:8E:C9:0C:61:84:F1:EA:7B:37:CB:56:1D:11:26:5B:F3:E0:F3:4B:F2:41:54:6E
 </pre>
 
 <p>Using the signature field, we can verify that the certificate was submitted to a log. Using our i<a href="https://letsencrypt.org/2018/04/04/sct-encoding.html">SCT deep dive guide</a>, you could further decode this value.</p>
 <pre>
-$ base64 -d <<< "BAMARzBFAiEA4OmuTcft9Jq3XLtcdZz9XinXCvYEY1RdSQICXayMJ+0CIHuujkKBLmQz5Cl/VG6C354cP9gxW0dfgMWB+A2yHi+E" | xxd -p -c 16 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
+$ base64 -d &lt;&lt;&lt; "BAMARzBFAiEA4OmuTcft9Jq3XLtcdZz9XinXCvYEY1RdSQICXayMJ+0CIHuujkKBLmQz5Cl/VG6C354cP9gxW0dfgMWB+A2yHi+E" | xxd -p -c 16 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
 04:03:00:47:30:45:02:21:00:E0:E9:AE:4D:C7:ED:F4
 9A:B7:5C:BB:5C:75:9C:FD:5E:29:D7:0A:F6:04:63:54
 5D:49:02:02:5D:AC:8C:27:ED:02:20:7B:AE:8E:42:81


### PR DESCRIPTION
Cf https://github.com/letsencrypt/website/pull/934#issuecomment-585662273